### PR TITLE
Feat: 메세지 생성 이벤트 구현

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: build/reports/jacoco/test/jacocoTestReport.xml
           flags: unittests
           name: codecov-coverage

--- a/src/main/java/com/sprint/mople/domain/dm/controller/DmApi.java
+++ b/src/main/java/com/sprint/mople/domain/dm/controller/DmApi.java
@@ -1,0 +1,40 @@
+package com.sprint.mople.domain.dm.controller;
+
+import com.sprint.mople.domain.dm.dto.ChatRoomResponse;
+import com.sprint.mople.domain.dm.dto.MessageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "DM", description = "DM 관련 API")
+public interface DmApi {
+
+  @Operation(summary = "채팅방 생성", description = "특정 사용자와의 채팅방을 생성합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "201", description = "채팅방이 성공적으로 생성됨",
+          content = @Content(schema = @Schema(implementation = ChatRoomResponse.class))
+      )
+  })
+  ResponseEntity<ChatRoomResponse> createChatRoom(@PathVariable UUID targetUserId,
+      HttpServletRequest request);
+
+  @Operation(summary = "채팅 조회", description = "특정 사용자와의 모든 메세지를 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "200", description = "메세지를 성공적으로 조회함",
+          content = @Content(schema = @Schema(implementation = MessageResponse.class))
+      )
+  })
+  ResponseEntity<List<MessageResponse>> findAllMessages(@PathVariable UUID targetUserId,
+      HttpServletRequest request);
+
+}

--- a/src/main/java/com/sprint/mople/domain/dm/controller/DmController.java
+++ b/src/main/java/com/sprint/mople/domain/dm/controller/DmController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/api/dm")
-public class ChatRoomController {
+public class DmController implements DmApi {
 
   private final ChatRoomService chatRoomService;
 
@@ -51,6 +51,5 @@ public class ChatRoomController {
     log.debug("{} 유저와의 전체 메세지 조회 완료: {}", targetUserId, response);
     return ResponseEntity.ok(response);
   }
-
 
 }

--- a/src/main/java/com/sprint/mople/domain/dm/controller/MessageController.java
+++ b/src/main/java/com/sprint/mople/domain/dm/controller/MessageController.java
@@ -21,8 +21,7 @@ public class MessageController {
 
   @MessageMapping("/messages")
   public void sendMessage(@Valid MessageCreateRequest request) {
-    MessageResponse response = messageService.create(request);
-    simpMessagingTemplate.convertAndSend("/sub/chatrooms/" + response.chatRoomId(), response);
+    messageService.create(request);
   }
 
 }

--- a/src/main/java/com/sprint/mople/domain/dm/controller/MessageController.java
+++ b/src/main/java/com/sprint/mople/domain/dm/controller/MessageController.java
@@ -1,21 +1,17 @@
 package com.sprint.mople.domain.dm.controller;
 
 import com.sprint.mople.domain.dm.dto.MessageCreateRequest;
-import com.sprint.mople.domain.dm.dto.MessageResponse;
 import com.sprint.mople.domain.dm.service.MessageService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
 @Slf4j
 @Controller
 @RequiredArgsConstructor
 public class MessageController {
-
-  private final SimpMessagingTemplate simpMessagingTemplate;
 
   private final MessageService messageService;
 

--- a/src/main/java/com/sprint/mople/domain/dm/controller/MessageController.java
+++ b/src/main/java/com/sprint/mople/domain/dm/controller/MessageController.java
@@ -3,6 +3,7 @@ package com.sprint.mople.domain.dm.controller;
 import com.sprint.mople.domain.dm.dto.MessageCreateRequest;
 import com.sprint.mople.domain.dm.dto.MessageResponse;
 import com.sprint.mople.domain.dm.service.MessageService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -19,7 +20,7 @@ public class MessageController {
   private final MessageService messageService;
 
   @MessageMapping("/messages")
-  public void sendMessage(MessageCreateRequest request) {
+  public void sendMessage(@Valid MessageCreateRequest request) {
     MessageResponse response = messageService.create(request);
     simpMessagingTemplate.convertAndSend("/sub/chatrooms/" + response.chatRoomId(), response);
   }

--- a/src/main/java/com/sprint/mople/domain/dm/dto/MessageCreateRequest.java
+++ b/src/main/java/com/sprint/mople/domain/dm/dto/MessageCreateRequest.java
@@ -1,11 +1,12 @@
 package com.sprint.mople.domain.dm.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import java.util.UUID;
 
 public record MessageCreateRequest(
-    UUID senderId,
-    UUID receiverId,
-    String content
+    @NotBlank(message = "보내는이 아이디가 없습니다.") UUID senderId,
+    @NotBlank(message = "받는이 아이디가 없습니다.") UUID receiverId,
+    @NotBlank(message = "내용이 없습니다.") String content
 ) {
 
 }

--- a/src/main/java/com/sprint/mople/domain/dm/event/MessageCreatedEvent.java
+++ b/src/main/java/com/sprint/mople/domain/dm/event/MessageCreatedEvent.java
@@ -1,0 +1,9 @@
+package com.sprint.mople.domain.dm.event;
+
+import com.sprint.mople.domain.dm.dto.MessageResponse;
+
+public record MessageCreatedEvent(
+    MessageResponse messageResponse
+) {
+
+}

--- a/src/main/java/com/sprint/mople/domain/dm/event/MessageEventListener.java
+++ b/src/main/java/com/sprint/mople/domain/dm/event/MessageEventListener.java
@@ -1,0 +1,21 @@
+package com.sprint.mople.domain.dm.event;
+
+import com.sprint.mople.domain.dm.dto.MessageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class MessageEventListener {
+
+  private final SimpMessagingTemplate simpMessagingTemplate;
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handleMessageCreatedEvent(MessageCreatedEvent event) {
+    MessageResponse message = event.messageResponse();
+    simpMessagingTemplate.convertAndSend("/sub/chatrooms/" + message.chatRoomId(), message);
+  }
+}

--- a/src/main/java/com/sprint/mople/domain/dm/event/MessageEventListener.java
+++ b/src/main/java/com/sprint/mople/domain/dm/event/MessageEventListener.java
@@ -16,6 +16,6 @@ public class MessageEventListener {
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handleMessageCreatedEvent(MessageCreatedEvent event) {
     MessageResponse message = event.messageResponse();
-    simpMessagingTemplate.convertAndSend("/sub/chatrooms/" + message.chatRoomId(), message);
+    simpMessagingTemplate.convertAndSend("/sub/dm/" + message.chatRoomId(), message);
   }
 }

--- a/src/main/java/com/sprint/mople/domain/dm/service/MessageServiceImpl.java
+++ b/src/main/java/com/sprint/mople/domain/dm/service/MessageServiceImpl.java
@@ -1,5 +1,6 @@
 package com.sprint.mople.domain.dm.service;
 
+import com.sprint.mople.domain.dm.event.MessageCreatedEvent;
 import com.sprint.mople.domain.dm.exception.ChatRoomNotFoundException;
 import com.sprint.mople.domain.dm.dto.ChatRoomResponse;
 import com.sprint.mople.domain.dm.dto.MessageCreateRequest;
@@ -16,6 +17,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +32,7 @@ public class MessageServiceImpl implements MessageService{
   private final UserRepository userRepository;
   private final ChatRoomService chatRoomService;
   private final MessageMapper messageMapper;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Transactional
   @Override
@@ -45,6 +48,7 @@ public class MessageServiceImpl implements MessageService{
         });
     Message message = new Message(chatRoom, sender, request.content());
     messageRepository.save(message);
+    eventPublisher.publishEvent(new MessageCreatedEvent(messageMapper.toDto(message)));
     log.debug("메세지 생성 완료 - 메세지 ID: {}", message.getId());
     return messageMapper.toDto(message);
   }

--- a/src/main/java/com/sprint/mople/domain/follow/controller/FollowApi.java
+++ b/src/main/java/com/sprint/mople/domain/follow/controller/FollowApi.java
@@ -1,0 +1,36 @@
+package com.sprint.mople.domain.follow.controller;
+
+import com.sprint.mople.domain.dm.dto.ChatRoomResponse;
+import com.sprint.mople.domain.follow.dto.FollowResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Follow", description = "팔로우 관련 API")
+public interface FollowApi {
+
+  @Operation(summary = "팔로우", description = "특정 사용자를 팔로우합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "201", description = "사용자를 성공적으로 팔로우함",
+          content = @Content(schema = @Schema(implementation = FollowResponse.class))
+      )
+  })
+  ResponseEntity<FollowResponse> follow(@PathVariable UUID followeeId, HttpServletRequest request);
+
+  @Operation(summary = "팔로우 취소", description = "특정 사용자를 언팔로우합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "204", description = "팔로우가 성공적으로 취소됨",
+          content = @Content(schema = @Schema(implementation = ChatRoomResponse.class))
+      )
+  })
+  void unfollow(@PathVariable UUID followeeId,HttpServletRequest request);
+}

--- a/src/main/java/com/sprint/mople/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/sprint/mople/domain/follow/controller/FollowController.java
@@ -1,13 +1,17 @@
 package com.sprint.mople.domain.follow.controller;
 
+import com.sprint.mople.domain.follow.dto.FollowResponse;
 import com.sprint.mople.domain.follow.service.FollowService;
+import com.sprint.mople.global.jwt.JwtProvider;
+import com.sprint.mople.global.jwt.JwtTokenExtractor;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,24 +19,26 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/follows")
-public class FollowController {
+public class FollowController implements FollowApi {
 
   private final FollowService followService;
 
+  private final JwtProvider jwtProvider;
+
   @PostMapping("/{followeeId}")
-  public void follow(@PathVariable UUID followeeId,
-//      @AuthenticationPrincipal MopleUserDetails userDetails, TODO: MopleUserDetails 구현 필요
-      @RequestHeader("USER-ID") UUID followerId) {
-    //    UUID followerId = userDetails.getId();
+  public ResponseEntity<FollowResponse> follow(@PathVariable UUID followeeId, HttpServletRequest request) {
+    String token = JwtTokenExtractor.resolveToken(request);
+    UUID followerId = jwtProvider.getUserId(token);
     log.debug("팔로우 요청 - 요청한 유저: {}, 팔로우 대상: {}", followeeId, followerId);
-    followService.follow(followerId, followeeId);
+    FollowResponse response = followService.follow(followerId, followeeId);
+    return ResponseEntity.ok(response);
   }
 
+
   @DeleteMapping("/{followeeId}")
-  public void unfollow(@PathVariable UUID followeeId,
-//      @AuthenticationPrincipal MopleUserDetails userDetails, TODO: MopleUserDetails 구현 필요
-      @RequestHeader("USER-ID") UUID followerId) {
-//    UUID followerId = userDetails.getId();
+  public void unfollow(@PathVariable UUID followeeId,HttpServletRequest request) {
+    String token = JwtTokenExtractor.resolveToken(request);
+    UUID followerId = jwtProvider.getUserId(token);
     log.debug("언팔로우 요청 - 요청한 유저: {}, 언팔로우 대상: {}", followeeId, followerId);
     followService.unfollow(followerId, followeeId);
   }

--- a/src/test/java/com/sprint/mople/domain/dm/service/MessageServiceImplTest.java
+++ b/src/test/java/com/sprint/mople/domain/dm/service/MessageServiceImplTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.context.event.SpringApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -43,6 +45,9 @@ class MessageServiceImplTest {
 
   @Mock
   ChatRoomService chatRoomService;
+
+  @Mock
+  ApplicationEventPublisher eventPublisher;
 
   @Mock
   MessageMapper messageMapper;


### PR DESCRIPTION
## 🛰️ Issue Number
- #31 
## 🪐 작업 내용
- 메세지 생성 시 이벤트를 발행하도록 구현
- Swagger 문서화 추가
## 📄 Description
- 스프링 이벤트를 통해 메세지 생성을 비동기 처리할 수 있도록 구현
  - `MessageController`와 `MessageEventListener`를 분리해 SRP 준수
- Swagger를 통해 API 문서화

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] PR 제목과 설명이 적절한가요?
