### PR TITLE
Feat: 팔로우와 DM 관련 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/sprint/mople/domain/dm/controller/DmApi.java
+++ b/src/main/java/com/sprint/mople/domain/dm/controller/DmApi.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 
@@ -37,4 +38,12 @@ public interface DmApi {
   ResponseEntity<List<MessageResponse>> findAllMessages(@PathVariable UUID targetUserId,
       HttpServletRequest request);
 
+  @Operation(summary = "채팅방 목록 조회", description = "사용자의 모든 채팅방을 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "200", description = "채팅방 목록을 성공적으로 조회함",
+          content = @Content(schema = @Schema(implementation = ChatRoomResponse.class))
+      )
+  })
+  ResponseEntity<Page<ChatRoomResponse>> findAllChatRooms(HttpServletRequest request);
 }

--- a/src/main/java/com/sprint/mople/domain/dm/controller/DmController.java
+++ b/src/main/java/com/sprint/mople/domain/dm/controller/DmController.java
@@ -1,16 +1,18 @@
 package com.sprint.mople.domain.dm.controller;
 
+import static com.sprint.mople.global.jwt.JwtTokenExtractor.extractUserId;
+
 import com.sprint.mople.domain.dm.dto.ChatRoomResponse;
 import com.sprint.mople.domain.dm.dto.MessageResponse;
 import com.sprint.mople.domain.dm.service.ChatRoomService;
 import com.sprint.mople.domain.dm.service.MessageService;
 import com.sprint.mople.global.jwt.JwtProvider;
-import com.sprint.mople.global.jwt.JwtTokenExtractor;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,8 +35,7 @@ public class DmController implements DmApi {
   @PostMapping("/{targetUserId}")
   public ResponseEntity<ChatRoomResponse> createChatRoom(@PathVariable UUID targetUserId,
       HttpServletRequest request) {
-    String token = JwtTokenExtractor.resolveToken(request);
-    UUID requestUserId = jwtProvider.getUserId(token);
+    UUID requestUserId = extractUserId(request, jwtProvider);
     log.debug("DM 채팅방 생성 요청: {}", targetUserId);
     ChatRoomResponse response = chatRoomService.createChatRoom(requestUserId, targetUserId);
     log.debug("DM 채팅방 생성 완료: {}", response);
@@ -44,11 +45,18 @@ public class DmController implements DmApi {
   @GetMapping("/{targetUserId}")
   public ResponseEntity<List<MessageResponse>> findAllMessages(@PathVariable UUID targetUserId,
       HttpServletRequest request) {
-    String token = JwtTokenExtractor.resolveToken(request);
-    UUID requestUserId = jwtProvider.getUserId(token);
+    UUID requestUserId = extractUserId(request, jwtProvider);
     log.debug("DM 채팅방 조회 요청: {}", targetUserId);
     List<MessageResponse> response = messageService.findAll(requestUserId, targetUserId);
     log.debug("{} 유저와의 전체 메세지 조회 완료: {}", targetUserId, response);
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping
+  public ResponseEntity<Page<ChatRoomResponse>> findAllChatRooms(HttpServletRequest request) {
+    UUID userId = extractUserId(request, jwtProvider);
+    log.debug("DM 채팅방 목록 조회 요청: {}", userId);
+    Page<ChatRoomResponse> response = chatRoomService.findAllChatRooms(userId);
     return ResponseEntity.ok(response);
   }
 

--- a/src/main/java/com/sprint/mople/domain/dm/entity/ChatRoom.java
+++ b/src/main/java/com/sprint/mople/domain/dm/entity/ChatRoom.java
@@ -12,13 +12,14 @@ import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "chat_rooms")
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatRoom {
 
   @Id

--- a/src/main/java/com/sprint/mople/domain/dm/event/MessageEventHandler.java
+++ b/src/main/java/com/sprint/mople/domain/dm/event/MessageEventHandler.java
@@ -9,7 +9,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
-public class MessageEventListener {
+public class MessageEventHandler {
 
   private final SimpMessagingTemplate simpMessagingTemplate;
 

--- a/src/main/java/com/sprint/mople/domain/dm/repository/ChatRoomRepository.java
+++ b/src/main/java/com/sprint/mople/domain/dm/repository/ChatRoomRepository.java
@@ -2,8 +2,17 @@ package com.sprint.mople.domain.dm.repository;
 
 import com.sprint.mople.domain.dm.entity.ChatRoom;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, UUID> {
 
+  @Query(
+      "SELECT cr FROM ChatRoom cr "
+          + "JOIN cr.participants cru "
+          + "WHERE cru.user.id = :userId"
+  )
+  Page<ChatRoom> findAllByParticipantId(UUID userId, Pageable pageable);
 }

--- a/src/main/java/com/sprint/mople/domain/dm/service/ChatRoomService.java
+++ b/src/main/java/com/sprint/mople/domain/dm/service/ChatRoomService.java
@@ -2,8 +2,11 @@ package com.sprint.mople.domain.dm.service;
 
 import com.sprint.mople.domain.dm.dto.ChatRoomResponse;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
 
 public interface ChatRoomService {
   ChatRoomResponse createChatRoom(UUID requestUserId, UUID targetUserId);
+
+  Page<ChatRoomResponse> findAllChatRooms(UUID userId);
 
 }

--- a/src/main/java/com/sprint/mople/domain/dm/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/sprint/mople/domain/dm/service/ChatRoomServiceImpl.java
@@ -9,13 +9,18 @@ import com.sprint.mople.domain.user.repository.UserRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class ChatRoomServiceImpl implements ChatRoomService{
+public class ChatRoomServiceImpl implements ChatRoomService {
+
+  private static final int DEFAULT_PAGE_SIZE = 10;
+  private static final int DEFAULT_PAGE_NUMBER = 0;
 
   private final ChatRoomRepository chatRoomRepository;
   private final UserRepository userRepository;
@@ -33,5 +38,20 @@ public class ChatRoomServiceImpl implements ChatRoomService{
     chatRoomRepository.save(chatRoom);
     log.debug("DM 채팅방 생성 완료 - 채팅방 ID: {}", chatRoom.getId());
     return chatRoomMapper.toDto(chatRoom);
+  }
+
+  @Override
+  public Page<ChatRoomResponse> findAllChatRooms(UUID userId) {
+    int page = DEFAULT_PAGE_NUMBER;
+    int size = DEFAULT_PAGE_SIZE;
+    log.debug("DM 채팅방 목록 조회 시작 - 유저: {}", userId);
+    Pageable pageable = Pageable.ofSize(size).withPage(page);
+    Page<ChatRoom> chatRooms = chatRoomRepository.findAllByParticipantId(userId, pageable);
+    if (chatRooms.isEmpty()) {
+      log.info("DM 채팅방 목록 조회 결과 없음 - 유저: {}", userId);
+      return Page.empty();
+    }
+    log.debug("DM 채팅방 목록 조회 완료 - 채팅방 수: {}", chatRooms.getTotalElements());
+    return chatRooms.map(chatRoomMapper::toDto);
   }
 }

--- a/src/main/java/com/sprint/mople/domain/dm/service/MessageServiceImpl.java
+++ b/src/main/java/com/sprint/mople/domain/dm/service/MessageServiceImpl.java
@@ -11,6 +11,8 @@ import com.sprint.mople.domain.dm.mapper.MessageMapper;
 import com.sprint.mople.domain.dm.repository.ChatRoomRepository;
 import com.sprint.mople.domain.dm.repository.ChatRoomUserRepository;
 import com.sprint.mople.domain.dm.repository.MessageRepository;
+import com.sprint.mople.domain.notification.entity.NotificationType;
+import com.sprint.mople.domain.notification.service.NotificationService;
 import com.sprint.mople.domain.user.entity.User;
 import com.sprint.mople.domain.user.repository.UserRepository;
 import java.util.List;
@@ -33,12 +35,15 @@ public class MessageServiceImpl implements MessageService{
   private final ChatRoomService chatRoomService;
   private final MessageMapper messageMapper;
   private final ApplicationEventPublisher eventPublisher;
+  private final NotificationService notificationService;
 
   @Transactional
   @Override
   public MessageResponse create(MessageCreateRequest request) {
     log.debug("메세지 생성 시작 - 보낸이: {}, 받는이: {}, 내용: {}", request.senderId(), request.receiverId(), request.content());
     User sender = userRepository.findById(request.senderId())
+        .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
+    User receiver = userRepository.findById(request.receiverId())
         .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
     ChatRoom chatRoom = chatRoomUserRepository.findChatRoomByUserIds(request.senderId(), request.receiverId())
         .orElseGet(()->  {
@@ -50,6 +55,10 @@ public class MessageServiceImpl implements MessageService{
     messageRepository.save(message);
     eventPublisher.publishEvent(new MessageCreatedEvent(messageMapper.toDto(message)));
     log.debug("메세지 생성 완료 - 메세지 ID: {}", message.getId());
+
+    String content = String.format("%s님이 새로운 메세지를 보냈습니다.", sender.getUserName());
+    notificationService.send(receiver, NotificationType.DM_RECEIVED, content, null);
+    log.debug("메세지 알림 전송 완료 - 대상: {}", receiver.getId());
     return messageMapper.toDto(message);
   }
 

--- a/src/main/java/com/sprint/mople/domain/follow/controller/FollowApi.java
+++ b/src/main/java/com/sprint/mople/domain/follow/controller/FollowApi.java
@@ -1,7 +1,7 @@
 package com.sprint.mople.domain.follow.controller;
 
-import com.sprint.mople.domain.dm.dto.ChatRoomResponse;
 import com.sprint.mople.domain.follow.dto.FollowResponse;
+import com.sprint.mople.domain.user.dto.UserListResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 
@@ -28,9 +29,26 @@ public interface FollowApi {
   @Operation(summary = "팔로우 취소", description = "특정 사용자를 언팔로우합니다.")
   @ApiResponses(value = {
       @ApiResponse(
-          responseCode = "204", description = "팔로우가 성공적으로 취소됨",
-          content = @Content(schema = @Schema(implementation = ChatRoomResponse.class))
+          responseCode = "204", description = "팔로우가 성공적으로 취소됨"
       )
   })
   void unfollow(@PathVariable UUID followeeId,HttpServletRequest request);
+
+  @Operation(summary = "팔로잉 목록", description = "사용자가 팔로우하는 대상 목록을 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "200", description = "팔로잉 목록 조회 성",
+          content = @Content(schema = @Schema(implementation = UserListResponse.class))
+      )
+  })
+  ResponseEntity<Page<UserListResponse>> findAllFollowings(HttpServletRequest request);
+
+  @Operation(summary = "팔로워 목록", description = "사용자를 팔로우하는 사람들의 목록을 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "200", description = "팔로워 목록 조회 성공",
+          content = @Content(schema = @Schema(implementation = UserListResponse.class))
+      )
+  })
+  ResponseEntity<Page<UserListResponse>> findAllFollowers(HttpServletRequest request);
 }

--- a/src/main/java/com/sprint/mople/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/sprint/mople/domain/follow/controller/FollowController.java
@@ -1,15 +1,19 @@
 package com.sprint.mople.domain.follow.controller;
 
+import static com.sprint.mople.global.jwt.JwtTokenExtractor.extractUserId;
+
 import com.sprint.mople.domain.follow.dto.FollowResponse;
 import com.sprint.mople.domain.follow.service.FollowService;
+import com.sprint.mople.domain.user.dto.UserListResponse;
 import com.sprint.mople.global.jwt.JwtProvider;
-import com.sprint.mople.global.jwt.JwtTokenExtractor;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,8 +31,7 @@ public class FollowController implements FollowApi {
 
   @PostMapping("/{followeeId}")
   public ResponseEntity<FollowResponse> follow(@PathVariable UUID followeeId, HttpServletRequest request) {
-    String token = JwtTokenExtractor.resolveToken(request);
-    UUID followerId = jwtProvider.getUserId(token);
+    UUID followerId = extractUserId(request, jwtProvider);
     log.debug("팔로우 요청 - 요청한 유저: {}, 팔로우 대상: {}", followeeId, followerId);
     FollowResponse response = followService.follow(followerId, followeeId);
     return ResponseEntity.ok(response);
@@ -37,9 +40,21 @@ public class FollowController implements FollowApi {
 
   @DeleteMapping("/{followeeId}")
   public void unfollow(@PathVariable UUID followeeId,HttpServletRequest request) {
-    String token = JwtTokenExtractor.resolveToken(request);
-    UUID followerId = jwtProvider.getUserId(token);
+    UUID followerId = extractUserId(request, jwtProvider);
     log.debug("언팔로우 요청 - 요청한 유저: {}, 언팔로우 대상: {}", followeeId, followerId);
     followService.unfollow(followerId, followeeId);
+  }
+
+  @GetMapping("/followings")
+  public ResponseEntity<Page<UserListResponse>> findAllFollowings(HttpServletRequest request) {
+    UUID userId = extractUserId(request, jwtProvider);
+    log.debug("팔로잉 목록 조회 요청 - 유저: {}", userId);
+    Page<UserListResponse> followings = followService.findAllFollowings(userId, 0, 10);
+    return ResponseEntity.ok(followings);
+  }
+
+  @GetMapping("/followers")
+  public ResponseEntity<Page<UserListResponse>> findAllFollowers(HttpServletRequest request) {
+    return null;
   }
 }

--- a/src/main/java/com/sprint/mople/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/sprint/mople/domain/follow/controller/FollowController.java
@@ -49,12 +49,15 @@ public class FollowController implements FollowApi {
   public ResponseEntity<Page<UserListResponse>> findAllFollowings(HttpServletRequest request) {
     UUID userId = extractUserId(request, jwtProvider);
     log.debug("팔로잉 목록 조회 요청 - 유저: {}", userId);
-    Page<UserListResponse> followings = followService.findAllFollowings(userId, 0, 10);
+    Page<UserListResponse> followings = followService.findAllFollowings(userId);
     return ResponseEntity.ok(followings);
   }
 
   @GetMapping("/followers")
   public ResponseEntity<Page<UserListResponse>> findAllFollowers(HttpServletRequest request) {
+    UUID userId = extractUserId(request, jwtProvider);
+    log.debug("팔로워 목록 조회 요청 - 유저: {}", userId);
+    Page<UserListResponse> followers = followService.findAllFollowers(userId);
     return null;
   }
 }

--- a/src/main/java/com/sprint/mople/domain/follow/exception/FollowAlreadyExistsException.java
+++ b/src/main/java/com/sprint/mople/domain/follow/exception/FollowAlreadyExistsException.java
@@ -3,9 +3,9 @@ package com.sprint.mople.domain.follow.exception;
 import com.sprint.mople.global.exception.ErrorCode;
 import com.sprint.mople.global.exception.MopleException;
 
-public class FollowNotFoundException extends MopleException {
+public class FollowAlreadyExistsException extends MopleException {
 
-  public FollowNotFoundException() {
-    super(ErrorCode.FOLLOW_NOT_FOUND);
+  public FollowAlreadyExistsException() {
+    super(ErrorCode.FOLLOW_ALREADY_EXISTS);
   }
-}
+  }

--- a/src/main/java/com/sprint/mople/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/sprint/mople/domain/follow/repository/FollowRepository.java
@@ -20,4 +20,11 @@ public interface FollowRepository extends JpaRepository<Follow, UUID> {
         WHERE f.follower = :follower
       """)
   Page<User> findFolloweesByFollower(@Param("follower") User follower, Pageable pageable);
+
+  @Query("""
+        SELECT f.follower
+        FROM Follow f
+        WHERE f.followee = :followee
+      """)
+  Page<User> findFollowersByFollowee(@Param("followee") User followee, Pageable pageable);
 }

--- a/src/main/java/com/sprint/mople/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/sprint/mople/domain/follow/repository/FollowRepository.java
@@ -14,17 +14,15 @@ public interface FollowRepository extends JpaRepository<Follow, UUID> {
 
   Optional<Follow> findByFollowerIdAndFolloweeId(UUID followerId, UUID followeeId);
 
-  @Query("""
-        SELECT f.followee
-        FROM Follow f
-        WHERE f.follower = :follower
-      """)
+  @Query(
+      "SELECT f.followee FROM Follow f"
+          + " WHERE f.follower = :follower"
+  )
   Page<User> findFolloweesByFollower(@Param("follower") User follower, Pageable pageable);
 
-  @Query("""
-        SELECT f.follower
-        FROM Follow f
-        WHERE f.followee = :followee
-      """)
+  @Query(
+      "SELECT f.follower FROM Follow f"
+          + " WHERE f.followee = :followee"
+  )
   Page<User> findFollowersByFollowee(@Param("followee") User followee, Pageable pageable);
 }

--- a/src/main/java/com/sprint/mople/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/sprint/mople/domain/follow/repository/FollowRepository.java
@@ -1,11 +1,23 @@
 package com.sprint.mople.domain.follow.repository;
 
 import com.sprint.mople.domain.follow.entity.Follow;
+import com.sprint.mople.domain.user.entity.User;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FollowRepository extends JpaRepository<Follow, UUID> {
 
   Optional<Follow> findByFollowerIdAndFolloweeId(UUID followerId, UUID followeeId);
+
+  @Query("""
+        SELECT f.followee
+        FROM Follow f
+        WHERE f.follower = :follower
+      """)
+  Page<User> findFolloweesByFollower(@Param("follower") User follower, Pageable pageable);
 }

--- a/src/main/java/com/sprint/mople/domain/follow/service/FollowService.java
+++ b/src/main/java/com/sprint/mople/domain/follow/service/FollowService.java
@@ -1,12 +1,18 @@
 package com.sprint.mople.domain.follow.service;
 
 import com.sprint.mople.domain.follow.dto.FollowResponse;
+import com.sprint.mople.domain.user.dto.UserListResponse;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
 
 public interface FollowService {
 
   FollowResponse follow(UUID followerId, UUID followeeId);
 
   void unfollow(UUID followerId, UUID followeeId);
+
+  Page<UserListResponse> findAllFollowings(UUID userId, int page, int size);
+
+  Page<UserListResponse> findAllFollowers(UUID userId, int page, int size);
 
 }

--- a/src/main/java/com/sprint/mople/domain/follow/service/FollowService.java
+++ b/src/main/java/com/sprint/mople/domain/follow/service/FollowService.java
@@ -11,8 +11,8 @@ public interface FollowService {
 
   void unfollow(UUID followerId, UUID followeeId);
 
-  Page<UserListResponse> findAllFollowings(UUID userId, int page, int size);
+  Page<UserListResponse> findAllFollowings(UUID userId);
 
-  Page<UserListResponse> findAllFollowers(UUID userId, int page, int size);
+  Page<UserListResponse> findAllFollowers(UUID userId);
 
 }

--- a/src/main/java/com/sprint/mople/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/sprint/mople/domain/follow/service/FollowServiceImpl.java
@@ -5,11 +5,14 @@ import com.sprint.mople.domain.follow.entity.Follow;
 import com.sprint.mople.domain.follow.exception.FollowNotFoundException;
 import com.sprint.mople.domain.follow.mapper.FollowMapper;
 import com.sprint.mople.domain.follow.repository.FollowRepository;
+import com.sprint.mople.domain.user.dto.UserListResponse;
 import com.sprint.mople.domain.user.entity.User;
 import com.sprint.mople.domain.user.repository.UserRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,5 +48,29 @@ public class FollowServiceImpl implements FollowService {
         .orElseThrow(FollowNotFoundException::new);
     followRepository.delete(follow);
     log.debug("언팔로우 완료 - 유저: {}, 언팔로우 대상: {}", followerId, followeeId);
+  }
+
+  @Override
+  public Page<UserListResponse> findAllFollowings(UUID userId, int page, int size) {
+    log.debug("팔로잉 목록 조회 시작 - 유저: {}, 페이지: {}, 사이즈: {}", userId, page, size);
+    Pageable pageable = Pageable.ofSize(size).withPage(page);
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다 - id: " + userId));
+
+    Page<User> followees = followRepository.findFolloweesByFollower(user, pageable);
+
+    log.debug("팔로잉 목록 조회 완료 - 유저: {}, 페이지: {}, 사이즈: {}", userId, page, size);
+    return followees.map(followee -> new UserListResponse(
+        followee.getUserName(),
+        followee.getEmail(),
+        followee.getIsLocked(),
+        followee.getCreateAt()
+    ));
+
+  }
+
+  @Override
+  public Page<UserListResponse> findAllFollowers(UUID userId, int page, int size) {
+    return null;
   }
 }

--- a/src/main/java/com/sprint/mople/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/sprint/mople/domain/follow/service/FollowServiceImpl.java
@@ -2,6 +2,7 @@ package com.sprint.mople.domain.follow.service;
 
 import com.sprint.mople.domain.follow.dto.FollowResponse;
 import com.sprint.mople.domain.follow.entity.Follow;
+import com.sprint.mople.domain.follow.exception.FollowAlreadyExistsException;
 import com.sprint.mople.domain.follow.exception.FollowNotFoundException;
 import com.sprint.mople.domain.follow.mapper.FollowMapper;
 import com.sprint.mople.domain.follow.repository.FollowRepository;
@@ -40,6 +41,10 @@ public class FollowServiceImpl implements FollowService {
     User followee = userRepository.findById(followeeId)
         .orElseThrow(
             () -> new IllegalArgumentException("팔로우 대상 유저를 찾을 수 없습니다 - id: " + followeeId));
+
+    if (followRepository.findByFollowerIdAndFolloweeId(followerId, followeeId).isPresent()){
+      throw new FollowAlreadyExistsException();
+    }
     Follow follow = new Follow(follower, followee);
     followRepository.save(follow);
     log.debug("팔로우 생성 완료 - 유저: {}, 팔로우 대상: {}", followerId, followeeId);
@@ -47,6 +52,7 @@ public class FollowServiceImpl implements FollowService {
     String content = String.format("%s님이 당신을 팔로우하기 시작했습니다.", follower.getUserName());
     notificationService.send(follower, NotificationType.NEW_FOLLOWER, content, null);
     log.debug("팔로우 알림 전송 완료 - 대상: {}", followerId);
+
     return followMapper.toDto(follow);
   }
 

--- a/src/main/java/com/sprint/mople/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/sprint/mople/domain/follow/service/FollowServiceImpl.java
@@ -65,7 +65,7 @@ public class FollowServiceImpl implements FollowService {
     Page<User> followees = followRepository.findFolloweesByFollower(user, pageable);
     if (followees.isEmpty()) {
       log.info("팔로잉 목록이 비어 있습니다 - 유저: {}", userId);
-      throw new FollowNotFoundException();
+      return Page.empty(pageable);
     }
 
     log.debug("팔로잉 목록 조회 완료 - 유저: {}, 페이지: {}, 사이즈: {}", userId, page, size);
@@ -89,7 +89,7 @@ public class FollowServiceImpl implements FollowService {
     Page<User> followers = followRepository.findFollowersByFollowee(user, pageable);
     if (followers.isEmpty()) {
       log.info("팔로워 목록이 비어 있습니다 - 유저: {}", userId);
-      throw new FollowNotFoundException();
+      return Page.empty(pageable);
     }
 
     log.debug("팔로워 목록 조회 완료 - 유저: {}, 페이지: {}, 사이즈: {}", userId, page, size);

--- a/src/main/java/com/sprint/mople/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/sprint/mople/domain/follow/service/FollowServiceImpl.java
@@ -5,6 +5,8 @@ import com.sprint.mople.domain.follow.entity.Follow;
 import com.sprint.mople.domain.follow.exception.FollowNotFoundException;
 import com.sprint.mople.domain.follow.mapper.FollowMapper;
 import com.sprint.mople.domain.follow.repository.FollowRepository;
+import com.sprint.mople.domain.notification.entity.NotificationType;
+import com.sprint.mople.domain.notification.service.NotificationService;
 import com.sprint.mople.domain.user.dto.UserListResponse;
 import com.sprint.mople.domain.user.entity.User;
 import com.sprint.mople.domain.user.repository.UserRepository;
@@ -27,6 +29,7 @@ public class FollowServiceImpl implements FollowService {
   private final FollowRepository followRepository;
   private final UserRepository userRepository;
   private final FollowMapper followMapper;
+  private final NotificationService notificationService;
 
   @Transactional
   @Override
@@ -40,6 +43,10 @@ public class FollowServiceImpl implements FollowService {
     Follow follow = new Follow(follower, followee);
     followRepository.save(follow);
     log.debug("팔로우 생성 완료 - 유저: {}, 팔로우 대상: {}", followerId, followeeId);
+
+    String content = String.format("%s님이 당신을 팔로우하기 시작했습니다.", follower.getUserName());
+    notificationService.send(follower, NotificationType.NEW_FOLLOWER, content, null);
+    log.debug("팔로우 알림 전송 완료 - 대상: {}", followerId);
     return followMapper.toDto(follow);
   }
 

--- a/src/main/java/com/sprint/mople/global/exception/ErrorCode.java
+++ b/src/main/java/com/sprint/mople/global/exception/ErrorCode.java
@@ -15,11 +15,13 @@ public enum ErrorCode {
 
   FOLLOW_NOT_FOUND(404, "F001", "팔로우 관계를 찾을 수 없습니다."),
 
+  FOLLOW_ALREADY_EXISTS(400, "F002", "이미 팔로우 관계가 존재합니다."),
+
   CHAT_ROOM_NOT_FOUND(404, "C001", "채팅방을 찾을 수 없습니다."),
 
   NOTIFICATION_NOT_FOUND(404, "N001", "알림을 찾을 수 없습니다."),
 
-  FORBIDDEN_ACCESS(403, "C001", "해당 리소스에 접근할 권한이 없습니다.");;
+  FORBIDDEN_ACCESS(403, "C001", "해당 리소스에 접근할 권한이 없습니다.");
 
   private final int status;   // HTTP Status
   private final String code;     // 도메인 식별 코드

--- a/src/main/java/com/sprint/mople/global/jwt/JwtTokenExtractor.java
+++ b/src/main/java/com/sprint/mople/global/jwt/JwtTokenExtractor.java
@@ -1,6 +1,7 @@
 package com.sprint.mople.global.jwt;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.UUID;
 
 public class JwtTokenExtractor {
 
@@ -10,6 +11,14 @@ public class JwtTokenExtractor {
       return bearer.substring(7);
     }
     return null;
+  }
+
+  public static UUID extractUserId(HttpServletRequest request, JwtProvider jwtProvider){
+    String token = resolveToken(request);
+    if (token == null) {
+      throw new IllegalArgumentException("JWT 토큰이 없습니다.");
+    }
+    return jwtProvider.getUserId(token);
   }
 
 }

--- a/src/test/java/com/sprint/mople/domain/dm/service/ChatRoomServiceImplTest.java
+++ b/src/test/java/com/sprint/mople/domain/dm/service/ChatRoomServiceImplTest.java
@@ -1,9 +1,11 @@
 package com.sprint.mople.domain.dm.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.sprint.mople.domain.dm.dto.ChatRoomResponse;
+import com.sprint.mople.domain.dm.entity.ChatRoom;
 import com.sprint.mople.domain.dm.mapper.ChatRoomMapper;
 import com.sprint.mople.domain.dm.repository.ChatRoomRepository;
 import com.sprint.mople.domain.user.entity.User;
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
 
 @ExtendWith(MockitoExtension.class)
 class ChatRoomServiceImplTest {
@@ -49,5 +52,25 @@ class ChatRoomServiceImplTest {
     assert (response.participantIds().contains(requestUserId));
     assert (response.participantIds().contains(userId));
 
+  }
+
+  void 채팅방_목록_조회(){
+    // Given
+    UUID userId = UUID.randomUUID();
+    ChatRoom chatRoom = new ChatRoom(new User(), new User());
+    ChatRoomResponse response = new ChatRoomResponse(UUID.randomUUID(), List.of(userId));
+
+    int page = 0;
+    int size = 10;
+
+    when(userRepository.findById(userId)).thenReturn(Optional.of(new User()));
+    when(chatRoomRepository.findAllByParticipantId(userId)).thenReturn(List.of(chatRoom));
+    when(chatRoomMapper.toDto(any())).thenReturn(response);
+
+    // When
+    Page<ChatRoomResponse> chatRooms = chatRoomService.findAllChatRooms(userId);
+
+    // Then
+    assertEquals(1, chatRooms.getTotalElements());
   }
 }

--- a/src/test/java/com/sprint/mople/domain/dm/service/ChatRoomServiceImplTest.java
+++ b/src/test/java/com/sprint/mople/domain/dm/service/ChatRoomServiceImplTest.java
@@ -19,6 +19,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 class ChatRoomServiceImplTest {
@@ -54,17 +56,19 @@ class ChatRoomServiceImplTest {
 
   }
 
+  @Test
   void 채팅방_목록_조회(){
     // Given
     UUID userId = UUID.randomUUID();
     ChatRoom chatRoom = new ChatRoom(new User(), new User());
     ChatRoomResponse response = new ChatRoomResponse(UUID.randomUUID(), List.of(userId));
-
     int page = 0;
     int size = 10;
 
-    when(userRepository.findById(userId)).thenReturn(Optional.of(new User()));
-    when(chatRoomRepository.findAllByParticipantId(userId)).thenReturn(List.of(chatRoom));
+    Pageable pageable = Pageable.ofSize(size).withPage(page);
+    Page<ChatRoom> chatRoomPage = new PageImpl<>(List.of(chatRoom), pageable, 1);
+
+    when(chatRoomRepository.findAllByParticipantId(userId, pageable)).thenReturn(chatRoomPage);
     when(chatRoomMapper.toDto(any())).thenReturn(response);
 
     // When

--- a/src/test/java/com/sprint/mople/domain/dm/service/MessageServiceImplTest.java
+++ b/src/test/java/com/sprint/mople/domain/dm/service/MessageServiceImplTest.java
@@ -13,6 +13,7 @@ import com.sprint.mople.domain.dm.mapper.MessageMapper;
 import com.sprint.mople.domain.dm.repository.ChatRoomRepository;
 import com.sprint.mople.domain.dm.repository.ChatRoomUserRepository;
 import com.sprint.mople.domain.dm.repository.MessageRepository;
+import com.sprint.mople.domain.notification.service.NotificationService;
 import com.sprint.mople.domain.user.entity.User;
 import com.sprint.mople.domain.user.repository.UserRepository;
 import java.time.Instant;
@@ -51,6 +52,9 @@ class MessageServiceImplTest {
 
   @Mock
   MessageMapper messageMapper;
+
+  @Mock
+  NotificationService notificationService;
 
   @InjectMocks
   MessageServiceImpl messageService;

--- a/src/test/java/com/sprint/mople/follow/FollowServiceImplTest.java
+++ b/src/test/java/com/sprint/mople/follow/FollowServiceImplTest.java
@@ -10,6 +10,7 @@ import com.sprint.mople.domain.follow.entity.Follow;
 import com.sprint.mople.domain.follow.mapper.FollowMapper;
 import com.sprint.mople.domain.follow.repository.FollowRepository;
 import com.sprint.mople.domain.follow.service.FollowServiceImpl;
+import com.sprint.mople.domain.notification.service.NotificationService;
 import com.sprint.mople.domain.user.dto.UserListResponse;
 import com.sprint.mople.domain.user.entity.User;
 import com.sprint.mople.domain.user.repository.UserRepository;
@@ -36,6 +37,9 @@ public class FollowServiceImplTest {
 
   @Mock
   FollowMapper followMapper;
+
+  @Mock
+  NotificationService notificationService;
 
   @InjectMocks
   FollowServiceImpl followService;

--- a/src/test/java/com/sprint/mople/follow/FollowServiceImplTest.java
+++ b/src/test/java/com/sprint/mople/follow/FollowServiceImplTest.java
@@ -94,7 +94,7 @@ public class FollowServiceImplTest {
         followeesPage);
 
     // When
-    Page<UserListResponse> responses = followService.findAllFollowings(userId, page, size);
+    Page<UserListResponse> responses = followService.findAllFollowings(userId);
 
     // Then
     assertEquals(1, responses.getTotalElements());
@@ -120,7 +120,7 @@ public class FollowServiceImplTest {
         followersPage);
 
     // When
-    Page<UserListResponse> responses = followService.findAllFollowers(userId, page, size);
+    Page<UserListResponse> responses = followService.findAllFollowers(userId);
 
     // Then
     assertEquals(1, responses.getTotalElements());

--- a/src/test/java/com/sprint/mople/follow/FollowServiceImplTest.java
+++ b/src/test/java/com/sprint/mople/follow/FollowServiceImplTest.java
@@ -9,8 +9,11 @@ import com.sprint.mople.domain.follow.entity.Follow;
 import com.sprint.mople.domain.follow.mapper.FollowMapper;
 import com.sprint.mople.domain.follow.repository.FollowRepository;
 import com.sprint.mople.domain.follow.service.FollowServiceImpl;
+import com.sprint.mople.domain.user.dto.UserListResponse;
 import com.sprint.mople.domain.user.entity.User;
 import com.sprint.mople.domain.user.repository.UserRepository;
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -18,6 +21,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 public class FollowServiceImplTest {
@@ -66,5 +71,26 @@ public class FollowServiceImplTest {
     followService.unfollow(followerId, followeeId);
 
     // Then
+  }
+
+  @Test
+  void 팔로잉_페이징_조회_성공(){
+    // Given
+    UUID userId = UUID.randomUUID();
+    UUID followeeId = UUID.randomUUID();
+    int page = 0;
+    int size = 10;
+
+    UserListResponse response = new UserListResponse(
+        "username", "user@email.com", false, Instant.now());
+    Pageable pageable = Pageable.ofSize(size).withPage(page);
+    when(followRepository.findByFollowerId(userId, pageable))
+        .thenReturn(List.of(followeeId));
+
+    // When
+    Page<UserListResponse> responses = followService.findAllFollowings(userId, page, size);
+
+    // Then
+    assertNotNull(followService.findAllFollowings(userId, page, size));
   }
 }

--- a/src/test/java/com/sprint/mople/follow/FollowServiceImplTest.java
+++ b/src/test/java/com/sprint/mople/follow/FollowServiceImplTest.java
@@ -13,7 +13,6 @@ import com.sprint.mople.domain.follow.service.FollowServiceImpl;
 import com.sprint.mople.domain.user.dto.UserListResponse;
 import com.sprint.mople.domain.user.entity.User;
 import com.sprint.mople.domain.user.repository.UserRepository;
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -96,6 +95,32 @@ public class FollowServiceImplTest {
 
     // When
     Page<UserListResponse> responses = followService.findAllFollowings(userId, page, size);
+
+    // Then
+    assertEquals(1, responses.getTotalElements());
+  }
+
+  @Test
+  void 팔로워_페이징_조회_성공() {
+    // Given
+    UUID userId = UUID.randomUUID();
+    User user = new User();
+    User follower = new User();
+    int page = 0;
+    int size = 10;
+
+    Pageable pageable = Pageable.ofSize(size).withPage(page);
+
+    List<User> followers = List.of(follower);
+    Page<User> followersPage = new PageImpl<>(followers, pageable, 1);
+
+    when(followRepository.findFollowersByFollowee(user, pageable)).thenReturn(followersPage);
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(followRepository.findFollowersByFollowee(user, pageable)).thenReturn(
+        followersPage);
+
+    // When
+    Page<UserListResponse> responses = followService.findAllFollowers(userId, page, size);
 
     // Then
     assertEquals(1, responses.getTotalElements());

--- a/src/test/java/com/sprint/mople/follow/FollowServiceImplTest.java
+++ b/src/test/java/com/sprint/mople/follow/FollowServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.sprint.mople.follow;
 
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -22,6 +23,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
@@ -77,20 +79,25 @@ public class FollowServiceImplTest {
   void 팔로잉_페이징_조회_성공(){
     // Given
     UUID userId = UUID.randomUUID();
-    UUID followeeId = UUID.randomUUID();
+    User user = new User();
+    User followee = new User();
     int page = 0;
     int size = 10;
 
-    UserListResponse response = new UserListResponse(
-        "username", "user@email.com", false, Instant.now());
     Pageable pageable = Pageable.ofSize(size).withPage(page);
-    when(followRepository.findByFollowerId(userId, pageable))
-        .thenReturn(List.of(followeeId));
+
+    List<User> followees = List.of(followee);
+    Page<User> followeesPage = new PageImpl<>(followees, pageable, 1);
+
+    when(followRepository.findFolloweesByFollower(user, pageable)).thenReturn(followeesPage);
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(followRepository.findFolloweesByFollower(user, pageable)).thenReturn(
+        followeesPage);
 
     // When
     Page<UserListResponse> responses = followService.findAllFollowings(userId, page, size);
 
     // Then
-    assertNotNull(followService.findAllFollowings(userId, page, size));
+    assertEquals(1, responses.getTotalElements());
   }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- #33 
## 🪐 작업 내용
- 팔로잉, 팔로워, dm 목록 페이지네이션 조회 구현
 
## 📄 Description

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] PR 제목과 설명이 적절한가요?
