### PR TITLE
Fix/45 : 팔로우와 DM 관련 목록 조회 시 연관 엔티티 조회 오류 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ out/
 .env.test.local
 .env.production.local
 .env.local
+
+### QueryDSL Q-classes ###
+/build/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'com.querydsl:querydsl-jpa:5.0.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
     id 'jacoco'
+    id "idea"
 }
 
 group = 'com.sprint4'
@@ -33,6 +34,7 @@ jacoco {
     toolVersion = "0.8.10"
 }
 
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -42,12 +44,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
-    implementation 'com.querydsl:querydsl-jpa:5.0.0'
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
@@ -70,3 +75,23 @@ jacocoTestReport {
         html.required = true
     }
 }
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += [
+            "-s", querydslDir
+    ]
+}
+
+idea {
+    module {
+        sourceDirs += file(querydslDir)
+        generatedSourceDirs += file(querydslDir)
+    }
+}
+
+clean {
+    delete file(querydslDir)
+}
+

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    patch:
+      default:
+        enabled: false

--- a/src/main/java/com/sprint/mople/domain/content/entity/Content.java
+++ b/src/main/java/com/sprint/mople/domain/content/entity/Content.java
@@ -85,7 +85,7 @@ public class Content {
   private Long totalRatingCount;
 
   @OneToMany(mappedBy = "content", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<PlaylistContent> playlistContents = new ArrayList<>();
+  private final List<PlaylistContent> playlistContents = new ArrayList<>();
 
   @Builder
   public Content(

--- a/src/main/java/com/sprint/mople/domain/dm/controller/DmApi.java
+++ b/src/main/java/com/sprint/mople/domain/dm/controller/DmApi.java
@@ -21,8 +21,7 @@ public interface DmApi {
   @Operation(summary = "채팅방 생성", description = "특정 사용자와의 채팅방을 생성합니다.")
   @ApiResponses(value = {
       @ApiResponse(
-          responseCode = "201", description = "채팅방이 성공적으로 생성됨",
-          content = @Content(schema = @Schema(implementation = ChatRoomResponse.class))
+          responseCode = "201", description = "채팅방이 성공적으로 생성됨"
       )
   })
   ResponseEntity<ChatRoomResponse> createChatRoom(@PathVariable UUID targetUserId,
@@ -31,9 +30,7 @@ public interface DmApi {
   @Operation(summary = "채팅 조회", description = "특정 사용자와의 모든 메세지를 조회합니다.")
   @ApiResponses(value = {
       @ApiResponse(
-          responseCode = "200", description = "메세지를 성공적으로 조회함",
-          content = @Content(schema = @Schema(implementation = MessageResponse.class))
-      )
+          responseCode = "200", description = "메세지를 성공적으로 조회함")
   })
   ResponseEntity<List<MessageResponse>> findAllMessages(@PathVariable UUID targetUserId,
       HttpServletRequest request);
@@ -41,9 +38,7 @@ public interface DmApi {
   @Operation(summary = "채팅방 목록 조회", description = "사용자의 모든 채팅방을 조회합니다.")
   @ApiResponses(value = {
       @ApiResponse(
-          responseCode = "200", description = "채팅방 목록을 성공적으로 조회함",
-          content = @Content(schema = @Schema(implementation = ChatRoomResponse.class))
-      )
+          responseCode = "200", description = "채팅방 목록을 성공적으로 조회함")
   })
   ResponseEntity<Page<ChatRoomResponse>> findAllChatRooms(HttpServletRequest request);
 }

--- a/src/main/java/com/sprint/mople/domain/dm/controller/DmApi.java
+++ b/src/main/java/com/sprint/mople/domain/dm/controller/DmApi.java
@@ -3,8 +3,6 @@ package com.sprint.mople.domain.dm.controller;
 import com.sprint.mople.domain.dm.dto.ChatRoomResponse;
 import com.sprint.mople.domain.dm.dto.MessageResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/com/sprint/mople/domain/dm/controller/MessageController.java
+++ b/src/main/java/com/sprint/mople/domain/dm/controller/MessageController.java
@@ -17,6 +17,7 @@ public class MessageController {
 
   @MessageMapping("/messages")
   public void sendMessage(@Valid MessageCreateRequest request) {
+    log.debug("메시지 전송 요청 - 보낸 사람: {}, 내용: {}", request.senderId(), request.content());
     messageService.create(request);
   }
 

--- a/src/main/java/com/sprint/mople/domain/dm/entity/ChatRoom.java
+++ b/src/main/java/com/sprint/mople/domain/dm/entity/ChatRoom.java
@@ -28,10 +28,10 @@ public class ChatRoom {
   private UUID id;
 
   @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<ChatRoomUser> participants = new ArrayList<>();
+  private final List<ChatRoomUser> participants = new ArrayList<>();
 
   @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<Message> messages = new ArrayList<>();
+  private final List<Message> messages = new ArrayList<>();
 
   public ChatRoom(User user1, User user2) {
     this.participants.add(new ChatRoomUser(this, user1));

--- a/src/main/java/com/sprint/mople/domain/dm/entity/ChatRoomUserId.java
+++ b/src/main/java/com/sprint/mople/domain/dm/entity/ChatRoomUserId.java
@@ -18,8 +18,7 @@ public class ChatRoomUserId implements Serializable {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof ChatRoomUserId)) return false;
-    ChatRoomUserId that = (ChatRoomUserId) o;
+    if (!(o instanceof ChatRoomUserId that)) return false;
     return Objects.equals(chatRoom, that.chatRoom) &&
         Objects.equals(user, that.user);
   }

--- a/src/main/java/com/sprint/mople/domain/dm/repository/ChatRoomRepository.java
+++ b/src/main/java/com/sprint/mople/domain/dm/repository/ChatRoomRepository.java
@@ -2,11 +2,9 @@ package com.sprint.mople.domain.dm.repository;
 
 import com.sprint.mople.domain.dm.entity.ChatRoom;
 import java.util.UUID;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
-public interface ChatRoomRepository extends JpaRepository<ChatRoom, UUID>, CustomChatRoomRepository {
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, UUID>,
+    CustomChatRoomRepository {
 
 }

--- a/src/main/java/com/sprint/mople/domain/dm/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/sprint/mople/domain/dm/repository/ChatRoomRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.sprint.mople.domain.dm.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sprint.mople.domain.dm.entity.ChatRoom;
+import com.sprint.mople.domain.dm.entity.QChatRoomUser;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import com.sprint.mople.domain.dm.entity.QChatRoom;
+
+@RequiredArgsConstructor
+public class ChatRoomRepositoryImpl implements CustomChatRoomRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Page<ChatRoom> findAllByUserIdWithParticipants(UUID userId, Pageable pageable) {
+    QChatRoom cr = QChatRoom.chatRoom;
+    QChatRoomUser cu = QChatRoomUser.chatRoomUser;
+
+    List<ChatRoom> content = queryFactory
+        .selectFrom(cr)
+        .distinct()
+        .join(cr.participants, cu).fetchJoin()
+        .where(cu.user.id.eq(userId))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    Long total = queryFactory
+        .select(cr.countDistinct())
+        .from(cr)
+        .join(cr.participants, cu)
+        .where(cu.user.id.eq(userId))
+        .fetchOne();
+
+    return new PageImpl<>(content, pageable, total != null ? total : 0);
+  }
+}

--- a/src/main/java/com/sprint/mople/domain/dm/repository/CustomChatRoomRepository.java
+++ b/src/main/java/com/sprint/mople/domain/dm/repository/CustomChatRoomRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomChatRoomRepository {
+
   Page<ChatRoom> findAllByUserIdWithParticipants(UUID userId, Pageable pageable);
 
 }

--- a/src/main/java/com/sprint/mople/domain/dm/repository/CustomChatRoomRepository.java
+++ b/src/main/java/com/sprint/mople/domain/dm/repository/CustomChatRoomRepository.java
@@ -4,9 +4,8 @@ import com.sprint.mople.domain.dm.entity.ChatRoom;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
-public interface ChatRoomRepository extends JpaRepository<ChatRoom, UUID>, CustomChatRoomRepository {
+public interface CustomChatRoomRepository {
+  Page<ChatRoom> findAllByUserIdWithParticipants(UUID userId, Pageable pageable);
 
 }

--- a/src/main/java/com/sprint/mople/domain/dm/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/sprint/mople/domain/dm/service/ChatRoomServiceImpl.java
@@ -46,7 +46,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     int size = DEFAULT_PAGE_SIZE;
     log.debug("DM 채팅방 목록 조회 시작 - 유저: {}", userId);
     Pageable pageable = Pageable.ofSize(size).withPage(page);
-    Page<ChatRoom> chatRooms = chatRoomRepository.findAllByParticipantId(userId, pageable);
+    Page<ChatRoom> chatRooms = chatRoomRepository.findAllByUserIdWithParticipants(userId, pageable);
     if (chatRooms.isEmpty()) {
       log.info("DM 채팅방 목록 조회 결과 없음 - 유저: {}", userId);
       return Page.empty();

--- a/src/main/java/com/sprint/mople/domain/follow/controller/FollowApi.java
+++ b/src/main/java/com/sprint/mople/domain/follow/controller/FollowApi.java
@@ -3,8 +3,6 @@ package com.sprint.mople.domain.follow.controller;
 import com.sprint.mople.domain.follow.dto.FollowResponse;
 import com.sprint.mople.domain.user.dto.UserListResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -31,7 +29,7 @@ public interface FollowApi {
           responseCode = "204", description = "팔로우가 성공적으로 취소됨"
       )
   })
-  void unfollow(@PathVariable UUID followeeId,HttpServletRequest request);
+  void unfollow(@PathVariable UUID followeeId, HttpServletRequest request);
 
   @Operation(summary = "팔로잉 목록", description = "사용자가 팔로우하는 대상 목록을 조회합니다.")
   @ApiResponses(value = {

--- a/src/main/java/com/sprint/mople/domain/follow/controller/FollowApi.java
+++ b/src/main/java/com/sprint/mople/domain/follow/controller/FollowApi.java
@@ -20,8 +20,7 @@ public interface FollowApi {
   @Operation(summary = "팔로우", description = "특정 사용자를 팔로우합니다.")
   @ApiResponses(value = {
       @ApiResponse(
-          responseCode = "201", description = "사용자를 성공적으로 팔로우함",
-          content = @Content(schema = @Schema(implementation = FollowResponse.class))
+          responseCode = "201", description = "사용자를 성공적으로 팔로우함"
       )
   })
   ResponseEntity<FollowResponse> follow(@PathVariable UUID followeeId, HttpServletRequest request);
@@ -37,8 +36,7 @@ public interface FollowApi {
   @Operation(summary = "팔로잉 목록", description = "사용자가 팔로우하는 대상 목록을 조회합니다.")
   @ApiResponses(value = {
       @ApiResponse(
-          responseCode = "200", description = "팔로잉 목록 조회 성",
-          content = @Content(schema = @Schema(implementation = UserListResponse.class))
+          responseCode = "200", description = "팔로잉 목록 조회 성공"
       )
   })
   ResponseEntity<Page<UserListResponse>> findAllFollowings(HttpServletRequest request);
@@ -46,8 +44,7 @@ public interface FollowApi {
   @Operation(summary = "팔로워 목록", description = "사용자를 팔로우하는 사람들의 목록을 조회합니다.")
   @ApiResponses(value = {
       @ApiResponse(
-          responseCode = "200", description = "팔로워 목록 조회 성공",
-          content = @Content(schema = @Schema(implementation = UserListResponse.class))
+          responseCode = "200", description = "팔로워 목록 조회 성공"
       )
   })
   ResponseEntity<Page<UserListResponse>> findAllFollowers(HttpServletRequest request);

--- a/src/main/java/com/sprint/mople/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/sprint/mople/domain/follow/controller/FollowController.java
@@ -30,7 +30,8 @@ public class FollowController implements FollowApi {
   private final JwtProvider jwtProvider;
 
   @PostMapping("/{followeeId}")
-  public ResponseEntity<FollowResponse> follow(@PathVariable UUID followeeId, HttpServletRequest request) {
+  public ResponseEntity<FollowResponse> follow(@PathVariable UUID followeeId,
+      HttpServletRequest request) {
     UUID followerId = extractUserId(request, jwtProvider);
     log.debug("팔로우 요청 - 요청한 유저: {}, 팔로우 대상: {}", followeeId, followerId);
     FollowResponse response = followService.follow(followerId, followeeId);
@@ -39,7 +40,7 @@ public class FollowController implements FollowApi {
 
 
   @DeleteMapping("/{followeeId}")
-  public void unfollow(@PathVariable UUID followeeId,HttpServletRequest request) {
+  public void unfollow(@PathVariable UUID followeeId, HttpServletRequest request) {
     UUID followerId = extractUserId(request, jwtProvider);
     log.debug("언팔로우 요청 - 요청한 유저: {}, 언팔로우 대상: {}", followeeId, followerId);
     followService.unfollow(followerId, followeeId);

--- a/src/main/java/com/sprint/mople/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/sprint/mople/domain/follow/controller/FollowController.java
@@ -39,6 +39,14 @@ public class FollowController implements FollowApi {
     return ResponseEntity.ok(response);
   }
 
+  @GetMapping("/{followeeId}")
+  public Boolean checkFollowing(@PathVariable UUID followeeId,
+      HttpServletRequest request) {
+    UUID followerId = extractUserId(request, jwtProvider);
+    log.debug("팔로우 상태 조회 요청 - 요청한 유저: {}, 팔로우 대상: {}", followeeId, followerId);
+    return followService.checkFollowing(followerId, followeeId);
+  }
+
   @DeleteMapping("/{followeeId}")
   public void unfollow(@PathVariable UUID followeeId, HttpServletRequest request) {
     UUID followerId = extractUserId(request, jwtProvider);

--- a/src/main/java/com/sprint/mople/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/sprint/mople/domain/follow/controller/FollowController.java
@@ -2,6 +2,7 @@ package com.sprint.mople.domain.follow.controller;
 
 import static com.sprint.mople.global.jwt.JwtTokenExtractor.extractUserId;
 
+import com.sprint.mople.domain.follow.dto.FollowCountResponse;
 import com.sprint.mople.domain.follow.dto.FollowResponse;
 import com.sprint.mople.domain.follow.service.FollowService;
 import com.sprint.mople.domain.user.dto.UserListResponse;
@@ -38,7 +39,6 @@ public class FollowController implements FollowApi {
     return ResponseEntity.ok(response);
   }
 
-
   @DeleteMapping("/{followeeId}")
   public void unfollow(@PathVariable UUID followeeId, HttpServletRequest request) {
     UUID followerId = extractUserId(request, jwtProvider);
@@ -60,5 +60,12 @@ public class FollowController implements FollowApi {
     log.debug("팔로워 목록 조회 요청 - 유저: {}", userId);
     Page<UserListResponse> followers = followService.findAllFollowers(userId);
     return ResponseEntity.ok(followers);
+  }
+
+  @GetMapping("/count")
+  public ResponseEntity<FollowCountResponse> getFollowCount(HttpServletRequest request) {
+    UUID userId = extractUserId(request, jwtProvider);
+    FollowCountResponse response = followService.getFollowCount(userId);
+    return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/sprint/mople/domain/follow/dto/FollowCountResponse.java
+++ b/src/main/java/com/sprint/mople/domain/follow/dto/FollowCountResponse.java
@@ -1,0 +1,8 @@
+package com.sprint.mople.domain.follow.dto;
+
+public record FollowCountResponse(
+    long followerCount,
+    long followeeCount
+) {
+
+}

--- a/src/main/java/com/sprint/mople/domain/follow/repository/CustomFollowRepository.java
+++ b/src/main/java/com/sprint/mople/domain/follow/repository/CustomFollowRepository.java
@@ -1,0 +1,14 @@
+package com.sprint.mople.domain.follow.repository;
+
+import com.sprint.mople.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CustomFollowRepository {
+
+  Page<User> findFolloweesByFollower(@Param("follower") User follower, Pageable pageable);
+
+  Page<User> findFollowersByFollowee(@Param("followee") User followee, Pageable pageable);
+}

--- a/src/main/java/com/sprint/mople/domain/follow/repository/CustomFollowRepository.java
+++ b/src/main/java/com/sprint/mople/domain/follow/repository/CustomFollowRepository.java
@@ -3,7 +3,6 @@ package com.sprint.mople.domain.follow.repository;
 import com.sprint.mople.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface CustomFollowRepository {

--- a/src/main/java/com/sprint/mople/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/sprint/mople/domain/follow/repository/FollowRepository.java
@@ -9,5 +9,4 @@ public interface FollowRepository extends JpaRepository<Follow, UUID>, CustomFol
 
   Optional<Follow> findByFollowerIdAndFolloweeId(UUID followerId, UUID followeeId);
 
-
 }

--- a/src/main/java/com/sprint/mople/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/sprint/mople/domain/follow/repository/FollowRepository.java
@@ -10,19 +10,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface FollowRepository extends JpaRepository<Follow, UUID> {
+public interface FollowRepository extends JpaRepository<Follow, UUID>, CustomFollowRepository {
 
   Optional<Follow> findByFollowerIdAndFolloweeId(UUID followerId, UUID followeeId);
 
-  @Query(
-      "SELECT f.followee FROM Follow f"
-          + " WHERE f.follower = :follower"
-  )
-  Page<User> findFolloweesByFollower(@Param("follower") User follower, Pageable pageable);
 
-  @Query(
-      "SELECT f.follower FROM Follow f"
-          + " WHERE f.followee = :followee"
-  )
-  Page<User> findFollowersByFollowee(@Param("followee") User followee, Pageable pageable);
 }

--- a/src/main/java/com/sprint/mople/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/sprint/mople/domain/follow/repository/FollowRepository.java
@@ -1,14 +1,9 @@
 package com.sprint.mople.domain.follow.repository;
 
 import com.sprint.mople.domain.follow.entity.Follow;
-import com.sprint.mople.domain.user.entity.User;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface FollowRepository extends JpaRepository<Follow, UUID>, CustomFollowRepository {
 

--- a/src/main/java/com/sprint/mople/domain/follow/repository/FollowRepositoryImpl.java
+++ b/src/main/java/com/sprint/mople/domain/follow/repository/FollowRepositoryImpl.java
@@ -1,0 +1,61 @@
+package com.sprint.mople.domain.follow.repository;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sprint.mople.domain.follow.entity.QFollow;
+import com.sprint.mople.domain.user.entity.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@RequiredArgsConstructor
+public class FollowRepositoryImpl implements CustomFollowRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Page<User> findFolloweesByFollower(User follower, Pageable pageable) {
+    QFollow follow = QFollow.follow;
+    JPAQuery<User> query = queryFactory
+        .select(follow.followee)
+        .from(follow)
+        .where(follow.follower.eq(follower));
+
+    List<User> content = query
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    Long count = queryFactory
+        .select(follow.count())
+        .from(follow)
+        .where(follow.follower.eq(follower))
+        .fetchOne();
+
+    return new PageImpl<>(content, pageable, count);
+  }
+
+  @Override
+  public Page<User> findFollowersByFollowee(User followee, Pageable pageable) {
+    QFollow follow = QFollow.follow;
+    JPAQuery<User> query = queryFactory
+        .select(follow.follower)
+        .from(follow)
+        .where(follow.followee.eq(followee));
+
+    List<User> content = query
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    Long count = queryFactory
+        .select(follow.count())
+        .from(follow)
+        .where(follow.followee.eq(followee))
+        .fetchOne();
+
+    return new PageImpl<>(content, pageable, count);
+  }
+}

--- a/src/main/java/com/sprint/mople/domain/follow/service/FollowService.java
+++ b/src/main/java/com/sprint/mople/domain/follow/service/FollowService.java
@@ -1,5 +1,6 @@
 package com.sprint.mople.domain.follow.service;
 
+import com.sprint.mople.domain.follow.dto.FollowCountResponse;
 import com.sprint.mople.domain.follow.dto.FollowResponse;
 import com.sprint.mople.domain.user.dto.UserListResponse;
 import java.util.UUID;
@@ -14,5 +15,7 @@ public interface FollowService {
   Page<UserListResponse> findAllFollowings(UUID userId);
 
   Page<UserListResponse> findAllFollowers(UUID userId);
+
+  FollowCountResponse getFollowCount(UUID userId);
 
 }

--- a/src/main/java/com/sprint/mople/domain/follow/service/FollowService.java
+++ b/src/main/java/com/sprint/mople/domain/follow/service/FollowService.java
@@ -18,4 +18,6 @@ public interface FollowService {
 
   FollowCountResponse getFollowCount(UUID userId);
 
+  Boolean checkFollowing(UUID followerId, UUID followeeId);
+
 }

--- a/src/main/java/com/sprint/mople/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/sprint/mople/domain/follow/service/FollowServiceImpl.java
@@ -131,4 +131,10 @@ public class FollowServiceImpl implements FollowService {
 
     return new FollowCountResponse(followerCount, followingCount);
   }
+
+  @Override
+  public Boolean checkFollowing(UUID followerId, UUID followeeId) {
+    log.debug("팔로우 상태 조회 시작 - 요청한 유저: {}, 팔로우 대상: {}", followerId, followeeId);
+    return followRepository.findByFollowerIdAndFolloweeId(followerId, followeeId).isPresent();
+  }
 }

--- a/src/main/java/com/sprint/mople/domain/playlist/entity/PlaylistLike.java
+++ b/src/main/java/com/sprint/mople/domain/playlist/entity/PlaylistLike.java
@@ -27,7 +27,7 @@ public class PlaylistLike {
   private Playlist playlist;
 
   @Column(name = "liked_at", nullable = false)
-  private Instant likedAt = Instant.now();
+  private final Instant likedAt = Instant.now();
 
   protected PlaylistLike() { }           // JPA 기본 생성자
 

--- a/src/main/java/com/sprint/mople/domain/user/service/TokenService.java
+++ b/src/main/java/com/sprint/mople/domain/user/service/TokenService.java
@@ -10,7 +10,7 @@ public interface TokenService {
   Map<String, String> generateTokens(UUID userId, String email);
 
   String refreshAccessToken(String refreshToken);
-  public Map<String, String> reissueTokens(String refreshToken, HttpServletResponse response);
+  Map<String, String> reissueTokens(String refreshToken, HttpServletResponse response);
 
   void logout(String refreshToken, HttpServletResponse response);
 }

--- a/src/main/java/com/sprint/mople/domain/user/service/UserService.java
+++ b/src/main/java/com/sprint/mople/domain/user/service/UserService.java
@@ -25,5 +25,5 @@ public interface UserService {
 
   UUID updateUserLockStatus(UUID userId, boolean locked);
 
-  public void resetPassword(String email);
+  void resetPassword(String email);
 }

--- a/src/main/java/com/sprint/mople/global/config/OpenApiConfig.java
+++ b/src/main/java/com/sprint/mople/global/config/OpenApiConfig.java
@@ -1,0 +1,23 @@
+package com.sprint.mople.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+    info = @Info(title = "Mople API", version = "v1"),
+    security = @SecurityRequirement(name = "bearerAuth")
+)
+@SecurityScheme(
+    name = "bearerAuth",
+    type = SecuritySchemeType.HTTP,
+    scheme = "bearer",
+    bearerFormat = "JWT"
+)
+public class OpenApiConfig {
+
+}

--- a/src/main/java/com/sprint/mople/global/config/QueryDSLConfig.java
+++ b/src/main/java/com/sprint/mople/global/config/QueryDSLConfig.java
@@ -1,0 +1,20 @@
+package com.sprint.mople.global.config;
+
+import com.querydsl.core.annotations.Config;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDSLConfig {
+  private final EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+
+}

--- a/src/main/java/com/sprint/mople/global/config/QueryDSLConfig.java
+++ b/src/main/java/com/sprint/mople/global/config/QueryDSLConfig.java
@@ -1,6 +1,5 @@
 package com.sprint.mople.global.config;
 
-import com.querydsl.core.annotations.Config;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @RequiredArgsConstructor
 public class QueryDSLConfig {
+
   private final EntityManager entityManager;
 
   @Bean

--- a/src/main/java/com/sprint/mople/global/exception/WebSocketExceptionHandler.java
+++ b/src/main/java/com/sprint/mople/global/exception/WebSocketExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.sprint.mople.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+
+@Slf4j
+@ControllerAdvice
+public class WebSocketExceptionHandler {
+
+  @MessageExceptionHandler(Exception.class)
+  public void handleWebSocketException(Exception e){
+    log.error("WebSocket 예외 발생: {}", e.getMessage(), e);
+  }
+
+}

--- a/src/test/java/com/sprint/mople/domain/dm/service/ChatRoomServiceImplTest.java
+++ b/src/test/java/com/sprint/mople/domain/dm/service/ChatRoomServiceImplTest.java
@@ -68,7 +68,7 @@ class ChatRoomServiceImplTest {
     Pageable pageable = Pageable.ofSize(size).withPage(page);
     Page<ChatRoom> chatRoomPage = new PageImpl<>(List.of(chatRoom), pageable, 1);
 
-    when(chatRoomRepository.findAllByParticipantId(userId, pageable)).thenReturn(chatRoomPage);
+    when(chatRoomRepository.findAllByUserIdWithParticipants(userId, pageable)).thenReturn(chatRoomPage);
     when(chatRoomMapper.toDto(any())).thenReturn(response);
 
     // When


### PR DESCRIPTION
## 🛰️ Issue Number
- #45 
## 🪐 작업 내용
- Swagger 문서화 시 응답 형식 제거
- 페이지네이션 조회 방법을 QueryDSL로 변경(fetch join + 페이지네이션)
- 프론트에서 필요한 기능 구현(팔로워/팔로잉 수 카운트, 팔로우 여부)

## 📄 Description
- 

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] PR 제목과 설명이 적절한가요?
