### PR TITLE
Fix : follow관련 api 파라미터 수정

### DIFF
--- a/src/main/java/com/sprint/mople/domain/follow/controller/FollowApi.java
+++ b/src/main/java/com/sprint/mople/domain/follow/controller/FollowApi.java
@@ -1,5 +1,6 @@
 package com.sprint.mople.domain.follow.controller;
 
+import com.sprint.mople.domain.follow.dto.FollowCountResponse;
 import com.sprint.mople.domain.follow.dto.FollowResponse;
 import com.sprint.mople.domain.user.dto.UserListResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -37,7 +38,7 @@ public interface FollowApi {
           responseCode = "200", description = "팔로잉 목록 조회 성공"
       )
   })
-  ResponseEntity<Page<UserListResponse>> findAllFollowings(HttpServletRequest request);
+  ResponseEntity<Page<UserListResponse>> findAllFollowings(@PathVariable UUID userId);
 
   @Operation(summary = "팔로워 목록", description = "사용자를 팔로우하는 사람들의 목록을 조회합니다.")
   @ApiResponses(value = {
@@ -45,5 +46,13 @@ public interface FollowApi {
           responseCode = "200", description = "팔로워 목록 조회 성공"
       )
   })
-  ResponseEntity<Page<UserListResponse>> findAllFollowers(HttpServletRequest request);
+  ResponseEntity<Page<UserListResponse>> findAllFollowers(@PathVariable UUID userId);
+
+  @Operation(summary = "팔로워, 팔로잉 수", description = "사용자를 팔로우, 팔로잉하는 사람들의 수를 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "200", description = "팔로워, 팔로잉 수 조회 성공"
+      )
+  })
+  ResponseEntity<FollowCountResponse> getFollowCount(@PathVariable UUID userId);
 }

--- a/src/main/java/com/sprint/mople/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/sprint/mople/domain/follow/controller/FollowController.java
@@ -54,25 +54,22 @@ public class FollowController implements FollowApi {
     followService.unfollow(followerId, followeeId);
   }
 
-  @GetMapping("/followings")
-  public ResponseEntity<Page<UserListResponse>> findAllFollowings(HttpServletRequest request) {
-    UUID userId = extractUserId(request, jwtProvider);
+  @GetMapping("/followings/{userId}")
+  public ResponseEntity<Page<UserListResponse>> findAllFollowings(@PathVariable UUID userId) {
     log.debug("팔로잉 목록 조회 요청 - 유저: {}", userId);
     Page<UserListResponse> followings = followService.findAllFollowings(userId);
     return ResponseEntity.ok(followings);
   }
 
-  @GetMapping("/followers")
-  public ResponseEntity<Page<UserListResponse>> findAllFollowers(HttpServletRequest request) {
-    UUID userId = extractUserId(request, jwtProvider);
+  @GetMapping("/followers/{userId}")
+  public ResponseEntity<Page<UserListResponse>> findAllFollowers(@PathVariable UUID userId) {
     log.debug("팔로워 목록 조회 요청 - 유저: {}", userId);
     Page<UserListResponse> followers = followService.findAllFollowers(userId);
     return ResponseEntity.ok(followers);
   }
 
-  @GetMapping("/count")
-  public ResponseEntity<FollowCountResponse> getFollowCount(HttpServletRequest request) {
-    UUID userId = extractUserId(request, jwtProvider);
+  @GetMapping("/count/{userId}")
+  public ResponseEntity<FollowCountResponse> getFollowCount(@PathVariable UUID userId) {
     FollowCountResponse response = followService.getFollowCount(userId);
     return ResponseEntity.ok(response);
   }

--- a/src/test/java/com/sprint/mople/domain/follow/controller/FollowControllerTest.java
+++ b/src/test/java/com/sprint/mople/domain/follow/controller/FollowControllerTest.java
@@ -87,14 +87,11 @@ class FollowControllerTest {
     List<UserListResponse> userResponses = List.of(userResponse);
     Page<UserListResponse> userResponsePage = new PageImpl<>(userResponses, PageRequest.of(0, 10),
         userResponses.size());
-    when(httpServletRequest.getHeader("Authorization")).thenReturn("Bearer token");
-    when(jwtProvider.getUserId("token")).thenReturn(followerId);
 
     when(followService.findAllFollowings(followerId)).thenReturn(userResponsePage);
 
     // When
-    ResponseEntity<Page<UserListResponse>> response = followController.findAllFollowings(
-        httpServletRequest);
+    ResponseEntity<Page<UserListResponse>> response = followController.findAllFollowings(followerId);
 
     // Then
     Page<UserListResponse> body = response.getBody();
@@ -104,26 +101,31 @@ class FollowControllerTest {
 
   @Test
   void 팔로워_전체_조회() {
-
     // Given
-    UUID followeeId = UUID.randomUUID();
-    UserListResponse userResponse = new UserListResponse("TestUser", "test@email.com", false,
-        Instant.now());
+    UUID userId = UUID.randomUUID();
+
+    UserListResponse userResponse = new UserListResponse(
+        "TestUser",
+        "test@email.com",
+        false,
+        Instant.now()
+    );
+
     List<UserListResponse> userResponses = List.of(userResponse);
-    Page<UserListResponse> userResponsePage = new PageImpl<>(userResponses, PageRequest.of(0, 10),
-        userResponses.size());
-    when(httpServletRequest.getHeader("Authorization")).thenReturn("Bearer token");
-    when(jwtProvider.getUserId("token")).thenReturn(followeeId);
-    when(followService.findAllFollowers(followeeId)).thenReturn(userResponsePage);
+    Page<UserListResponse> userResponsePage = new PageImpl<>(
+        userResponses,
+        PageRequest.of(0, 10),
+        userResponses.size()
+    );
+
+    when(followService.findAllFollowers(userId)).thenReturn(userResponsePage);
 
     // When
-    ResponseEntity<Page<UserListResponse>> response = followController.findAllFollowers(
-        httpServletRequest);
+    ResponseEntity<Page<UserListResponse>> response = followController.findAllFollowers(userId);
 
     // Then
-    Page<UserListResponse> body = response.getBody();
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(body.getContent().get(0).userName()).isEqualTo("TestUser");
-
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getContent().get(0).userName()).isEqualTo("TestUser");
   }
 }


### PR DESCRIPTION
- AccessToken으로 사용시 다른 유저의 정보를 가져올 수 없는 이슈 발생
- userId로 수정하여 해결

## 🛰️ Issue Number
- #53 
## 🪐 작업 내용
- follow관련 api 파라미터 AccessToken에서 userId로 변경
## 📄 Description
- AccessToken으로 진행 시 타인 프로필에 접근할 경우 AcessToken이 없기 때문에 정보를 가져오지 못함
- userId를 이용하여 모든 사용자의 정보를 가져올 수 있도록 함
- 다만, AccessToken을 이용하여 본인인지 타인인지 비교할 수 있도록 진행하였음

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] PR 제목과 설명이 적절한가요?
